### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Eckhardt, P., Ernst, K., Fleischmann, T., Geßler, A., Schnickmann, K., Thurner,
 
 The package was developed as part of Bachelor's theses:
 
-- Fleischmann, T. (2025). Advances in literature search queries: Validation and translation of search strings for EBSCO host. Otto-Friedrich-University of Bamberg.
+- Fleischmann, T. (2025). Advances in literature search queries: Validation and translation of search strings for EBSCOHost. Otto-Friedrich-University of Bamberg.
 - Geßler, A. (2025). Design of an Emulator for API-based Academic Literature Searches. Otto-Friedrich-University of Bamberg.
 - Schnickmann, K. (2025). Validating and Parsing Academic Search Queries: A Design Science Approach. Otto-Friedrich-University of Bamberg.
 - Eckhardt, P. (2025). Advances in literature searches: Evaluation, analysis, and improvement of Web of Science queries. Otto-Friedrich-University of Bamberg.
@@ -36,7 +36,7 @@ The package was developed as part of Bachelor's theses:
 
 ## Not what you are looking for?
 
-This Python package was developed with purpose of integrating it into other literature management tools. If that isn't your use case, it might be useful for you to look at these related tools:
+This Python package was developed with the purpose of integrating it into other literature management tools. If that isn't your use case, it might be useful for you to look at these related tools:
 
 - [LitSonar](https://litsonar.com/)
 - [Polyglot](https://sr-accelerator.com/#/polyglot)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,7 +72,7 @@ A useful feature of parsers is the built-in **linter** functionality, which help
     #                                                ^^^
 
 Once we have created a :literal:`query` object, we can translate it for different databases.
-Note how the syntax is translated and how the search for :literal:`Title/Abstract` is spit into two elements:
+Note how the syntax is translated and how the search for :literal:`Title/Abstract` is split into two elements:
 
 .. code-block:: python
    :linenos:

--- a/docs/source/translate.rst
+++ b/docs/source/translate.rst
@@ -5,7 +5,7 @@ Translate
 
 ..
    TODO
-   also desribe how to translate to list format (flag/option for to-string methods)
+   also describe how to translate to list format (flag/option for to-string methods)
 
 .. code-block:: python
    :linenos:

--- a/release-checklist.md
+++ b/release-checklist.md
@@ -2,17 +2,17 @@
 
 - Use constants.
 - Collect release notes and update the `CHANGELOG.md`.
-- Update **version** and **date**  and date in `CITATION.cff`.
+- Update **version** and **date** in `CITATION.cff`.
 - Update the version in `pyproject.toml`.
 - Commit the changes (`release 0.10.0`).
-- Push to Github. Check whether the installation, tests, and pre-commit hooks pass.
+- Push to GitHub. Check whether the installation, tests, and pre-commit hooks pass.
 - Run `git tag -s $VERSION` (format: "0.9.1").
 - Run `pip install -e .` locally (before testing upgrade in local repositories).
 - Run `git push` and wait for the GitHub actions to complete successfully.
 - Check whether the tests pass locally (``pytest tests``).
 - Run `git push --atomic origin main $VERSION`.
 
-- Create [new release on Github](https://github.com/CoLRev-Environment/search-query/releases/new)
+- Create [new release on GitHub](https://github.com/CoLRev-Environment/search-query/releases/new)
     - Select new tag
     - Enter the release notes
     - Publish the release


### PR DESCRIPTION
## Summary
- fix small typos in docs and checklists
- improve README phrasing and EBSCOHost spelling

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'search_query')*


------
https://chatgpt.com/codex/tasks/task_e_686cdd7c0c38832ab3a58451aa7b87e6