### PR TITLE
Unify CLI with sub-commands

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -10,16 +10,11 @@ To translate a search query on the command line, run
 
 .. code-block:: bash
 
-    search-query-translate --from wos \
-                            --input input_query.txt \
+    search-query translate --input input_query.json \
                             --to pubmed \
-                            --output output_query.txt
+                            --output output_query.json
 
 **Arguments**
-
-- ``--from`` (required):
-  The source query format.
-  Example: ``wos``
 
 - ``--input`` (required):
   Path to the input file containing the original query.
@@ -31,22 +26,10 @@ To translate a search query on the command line, run
 - ``--output`` (required):
   Path to the file where the converted query will be written.
 
-
-**Example**
-
-Suppose you have a Web of Science search query saved in ``input_query.txt`` and you want to convert it to a PubMed-compatible format. Run:
-
-.. code-block:: bash
-
-    search-query-translate --from wos \
-                            --input input_query.txt \
-                            --to pubmed \
-                            --output output_query.txt
-
-The converted query will be saved in ``output_query.txt``.
+The format of the ``input_query.json`` is stored in the ``platform`` field of the JSON file.
 
 Linters can be run on the CLI:
 
 .. code-block:: bash
 
-    search-query-lint search-file.json
+    search-query lint search-file.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ dev = [
 ]
 
 [project.scripts]
-search-query-translate = "search_query.cli:translate"
-search-query-lint = "search_query.cli:lint"
+search-query = "search_query.cli:main"
 
 [tool.pylint.MAIN]
 extension-pkg-whitelist = "lxml.etree"

--- a/search_query/linter.py
+++ b/search_query/linter.py
@@ -20,20 +20,19 @@ def _get_parser(
 ) -> QueryStringParser:
     """Run the linter on the search string"""
 
+    platform = search_query.parser.get_platform(platform)
     parser_class = search_query.parser.PARSERS[platform]
     parser = parser_class(search_string, field_general=field_general)  # type: ignore
 
     try:
         parser.parse()
     except Exception as exc:
-        print(f"Error parsing query: {exc}")
         assert parser.linter.messages  # type: ignore
     return parser
 
 
 def lint_file(search_file: SearchFile) -> dict:
     """Lint a search file and return the messages."""
-    # pylint: disable=too-many-locals
     platform = search_query.parser.get_platform(search_file.platform)
     if platform not in search_query.parser.PARSERS:
         raise ValueError(
@@ -43,7 +42,7 @@ def lint_file(search_file: SearchFile) -> dict:
 
     return lint_query_string(
         search_file.search_string,
-        platform=search_file.platform,
+        platform=platform,
         field_general=search_file.field,
     )
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -16,8 +16,8 @@ def test_translate_cli() -> None:
 
     result = subprocess.run(
         [
-            "search-query-translate",
-            "--from=wos",
+            "search-query",
+            "translate",
             f"--input={input_file}",
             "--to=ebscohost",
             f"--output={output_file}",
@@ -28,7 +28,7 @@ def test_translate_cli() -> None:
     print(result.stdout)
     print(result.stderr)
     assert result.returncode == 0
-    assert "Converting from wos to ebscohost" in result.stdout
+    assert "Converting from Web of Science to ebscohost" in result.stdout
     assert "Writing converted query to" in result.stdout
     assert output_file.exists()
 
@@ -44,7 +44,7 @@ def test_linter_cli() -> None:
     input_file = test_data_dir / "search_history_file_2_linter.json"
 
     result = subprocess.run(
-        ["search-query-lint", f"{input_file}"],
+        ["search-query", "lint", f"{input_file}"],
         capture_output=True,
         text=True,
     )
@@ -53,7 +53,6 @@ def test_linter_cli() -> None:
     print("STDERR:", result.stderr)
     print("RETURN CODE:", result.returncode)
 
-    assert "Lint: search_history_file_2_linter.json (wos)" in result.stdout
     assert "Unbalanced closing parenthesis" in result.stdout
     assert (
         "The query uses multiple operators with different precedence levels"


### PR DESCRIPTION
Revised the CLI to expose two sub-commands:

```
search-query lint
```

```
search-query translate
```

Updated tests and docs accordingly.

In response to https://github.com/CoLRev-Environment/search-query/issues/51