### PR TITLE
Parser: raise exception instead of sys.exit()

### DIFF
--- a/search_query/parser.py
+++ b/search_query/parser.py
@@ -50,7 +50,7 @@ def parse(
                 query_list=query_str,
                 field_general=field_general,
             ).parse()
-        except QuerySyntaxError as exc:  # pylint: disable=broad-except
+        except QuerySyntaxError as exc:
             raise exc
         return query
 
@@ -62,7 +62,7 @@ def parse(
         query = parser_class(
             query_str, field_general=field_general
         ).parse()  # type: ignore
-    except QuerySyntaxError as exc:  # pylint: disable=broad-except
+    except QuerySyntaxError as exc:
         raise exc
 
     return query


### PR DESCRIPTION
Revised the parser to raise an exception that can be handled by a system using `search-query` as a library (in response to #49 ). Example for exception handling:

```python

from search_query.parser import parse
from search_query.exception import QuerySyntaxError

query_string = '("digital health"[Title/Abstract]) AND ("privacy"[Title/Abstract]'

try:
    query = parse(query_string, platform="pubmed")
except QuerySyntaxError as exc:
    print('handle gracefully')
```