### PR TITLE
Improve registry type hints and documentation

### DIFF
--- a/search_query/ebscohost/v_1_0_0/parser.py
+++ b/search_query/ebscohost/v_1_0_0/parser.py
@@ -2,9 +2,13 @@
 """Versioned EBSCO parser wrappers."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.ebscohost.linter import EBSCOListLinter
-from search_query.ebscohost.parser import EBSCOListParser
-from search_query.ebscohost.parser import EBSCOParser
+from search_query.ebscohost.parser import EBSCOListParser, EBSCOParser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 # pylint: disable=too-few-public-methods
 
@@ -26,6 +30,8 @@ class EBSCOListParser_v1_0_0(EBSCOListParser):
         self.linter = EBSCOListLinter(self, EBSCOParser_v1_0_0)
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register these parsers with the ``registry``."""
+
     registry.register_parser_string(platform, version, EBSCOParser_v1_0_0)
     registry.register_parser_list(platform, version, EBSCOListParser_v1_0_0)

--- a/search_query/ebscohost/v_1_0_0/serializer.py
+++ b/search_query/ebscohost/v_1_0_0/serializer.py
@@ -2,17 +2,23 @@
 """EBSCO serializer for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.ebscohost.serializer import EBSCOQuerySerializer
 
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
+
+
 # pylint: disable=too-few-public-methods
-
-
 class EBCOSerializer_v1_0_0(EBSCOQuerySerializer):
     """EBSCO serializer for version 1.0.0."""
 
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this serializer with the ``registry``."""
+
     registry.register_serializer_string(platform, version, EBCOSerializer_v1_0_0)
     registry.register_serializer_list(platform, version, EBCOSerializer_v1_0_0)

--- a/search_query/ebscohost/v_1_0_0/translator.py
+++ b/search_query/ebscohost/v_1_0_0/translator.py
@@ -2,7 +2,12 @@
 """EBSCO translator for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.ebscohost.translator import EBSCOTranslator
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 class EBSCOTranslator_v1_0_0(EBSCOTranslator):
@@ -11,5 +16,7 @@ class EBSCOTranslator_v1_0_0(EBSCOTranslator):
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this translator with the ``registry``."""
+
     registry.register_translator(platform, version, EBSCOTranslator_v1_0_0)

--- a/search_query/generic/v_1_0_0/serializer.py
+++ b/search_query/generic/v_1_0_0/serializer.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python3
+"""Generic serializer for version 1.0.0."""
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from search_query.generic.serializer import GenericSerializer
 
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
-class GenericSerializer_v_1_0_0(GenericSerializer):
+
+# pylint: disable=too-few-public-methods
+class GenericSerializer_v1_0_0(GenericSerializer):
     """Generic serializer for version 1.0.0."""
 
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
-    registry.register_serializer_string(platform, version, GenericSerializer_v_1_0_0)
-    registry.register_serializer_list(platform, version, GenericSerializer_v_1_0_0)
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this serializer with the ``registry``."""
+
+    registry.register_serializer_string(platform, version, GenericSerializer_v1_0_0)
+    registry.register_serializer_list(platform, version, GenericSerializer_v1_0_0)

--- a/search_query/pubmed/v_1_0_0/parser.py
+++ b/search_query/pubmed/v_1_0_0/parser.py
@@ -2,9 +2,13 @@
 """Versioned PubMed parser wrappers."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.pubmed.linter import PubmedQueryListLinter
-from search_query.pubmed.parser import PubmedListParser
-from search_query.pubmed.parser import PubmedParser
+from search_query.pubmed.parser import PubmedListParser, PubmedParser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 class PubMedParser_v1_0_0(PubmedParser):
@@ -25,6 +29,8 @@ class PubMedListParser_v1_0_0(PubmedListParser):
         self.linter = PubmedQueryListLinter(self, PubMedParser_v1_0_0)
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register these parsers with the ``registry``."""
+
     registry.register_parser_string(platform, version, PubMedParser_v1_0_0)
     registry.register_parser_list(platform, version, PubMedListParser_v1_0_0)

--- a/search_query/pubmed/v_1_0_0/serializer.py
+++ b/search_query/pubmed/v_1_0_0/serializer.py
@@ -2,18 +2,23 @@
 """PubMed serializer for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.pubmed.serializer import PUBMEDQuerySerializer
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 # pylint: disable=too-few-public-methods
-
-
 class PubMedSerializer_v1_0_0(PUBMEDQuerySerializer):
     """PubMed serializer for version 1.0.0."""
 
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this serializer with the ``registry``."""
+
     registry.register_serializer_string(platform, version, PubMedSerializer_v1_0_0)
     registry.register_serializer_list(platform, version, PubMedSerializer_v1_0_0)

--- a/search_query/pubmed/v_1_0_0/translator.py
+++ b/search_query/pubmed/v_1_0_0/translator.py
@@ -2,7 +2,12 @@
 """PubMed translator for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.pubmed.translator import PubmedTranslator
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 class PubMedTranslator_v1_0_0(PubmedTranslator):
@@ -11,5 +16,7 @@ class PubMedTranslator_v1_0_0(PubmedTranslator):
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this translator with the ``registry``."""
+
     registry.register_translator(platform, version, PubMedTranslator_v1_0_0)

--- a/search_query/upgrade.py
+++ b/search_query/upgrade.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Optional
 
-from search_query.registry import LATEST_PARSERS
-from search_query.registry import PARSERS
-from search_query.registry import SERIALIZERS
-from search_query.registry import TRANSLATORS
+from search_query.registry import (
+    LATEST_VERSIONS_PARSERS,
+    PARSERS,
+    SERIALIZERS,
+    TRANSLATORS,
+)
 
 
 def upgrade_query(
@@ -36,8 +38,9 @@ def upgrade_query(
       Where unavoidable, translators should emit warnings about lossy conversions.
     """
 
-    if not version_target or version_target.lower() == "latest":
-        version_target = LATEST_PARSERS[platform]
+    if version_target is None or version_target.lower() == "latest":
+        version_target = LATEST_VERSIONS_PARSERS[platform]
+    assert version_target is not None
 
     # 1) Parse source query string into a query object.
     parser_cls = PARSERS[platform][version_current]

--- a/search_query/wos/v_1_0_0/parser.py
+++ b/search_query/wos/v_1_0_0/parser.py
@@ -2,9 +2,13 @@
 """Versioned Web of Science parser wrappers."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.wos.linter import WOSQueryListLinter
-from search_query.wos.parser import WOSListParser
-from search_query.wos.parser import WOSParser
+from search_query.wos.parser import WOSListParser, WOSParser
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 class WOSParser_v1_0_0(WOSParser):
@@ -24,6 +28,8 @@ class WOSListParser_v1_0_0(WOSListParser):
         self.linter = WOSQueryListLinter(self, WOSParser_v1_0_0)
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register these parsers with the ``registry``."""
+
     registry.register_parser_string(platform, version, WOSParser_v1_0_0)
     registry.register_parser_list(platform, version, WOSListParser_v1_0_0)

--- a/search_query/wos/v_1_0_0/serializer.py
+++ b/search_query/wos/v_1_0_0/serializer.py
@@ -2,17 +2,23 @@
 """Web of Science serializer for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.wos.serializer import WOSQuerySerializer
 
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
+
+
 # pylint: disable=too-few-public-methods
-
-
 class WOSSerializer_v1_0_0(WOSQuerySerializer):
     """Web of Science serializer for version 1.0.0."""
 
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this serializer with the ``registry``."""
+
     registry.register_serializer_string(platform, version, WOSSerializer_v1_0_0)
     registry.register_serializer_list(platform, version, WOSSerializer_v1_0_0)

--- a/search_query/wos/v_1_0_0/translator.py
+++ b/search_query/wos/v_1_0_0/translator.py
@@ -2,7 +2,12 @@
 """Web of Science translator for version 1.0.0."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from search_query.wos.translator import WOSTranslator
+
+if TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
 
 
 class WOSTranslator_v1_0_0(WOSTranslator):
@@ -11,5 +16,7 @@ class WOSTranslator_v1_0_0(WOSTranslator):
     VERSION = "1.0.0"
 
 
-def register(registry, *, platform: str, version: str) -> None:
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this translator with the ``registry``."""
+
     registry.register_translator(platform, version, WOSTranslator_v1_0_0)


### PR DESCRIPTION
## Summary
- add type aliases and discovery helper in registry
- clarify version upgrade logic
- document and type register functions for versioned parsers, serializers and translators
- rename internal `_Registry` to public `Registry`

## Testing
- `ruff check search_query/registry.py search_query/generic/v_1_0_0/serializer.py search_query/wos/v_1_0_0/parser.py search_query/wos/v_1_0_0/translator.py search_query/wos/v_1_0_0/serializer.py search_query/pubmed/v_1_0_0/parser.py search_query/pubmed/v_1_0_0/translator.py search_query/pubmed/v_1_0_0/serializer.py search_query/ebscohost/v_1_0_0/parser.py search_query/ebscohost/v_1_0_0/translator.py search_query/ebscohost/v_1_0_0/serializer.py`
- `mypy --config-file=/dev/null --python-version 3.11 --follow-imports=skip --ignore-missing-imports search_query/registry.py search_query/generic/v_1_0_0/serializer.py search_query/wos/v_1_0_0/parser.py search_query/wos/v_1_0_0/translator.py search_query/wos/v_1_0_0/serializer.py search_query/pubmed/v_1_0_0/parser.py search_query/pubmed/v_1_0_0/translator.py search_query/pubmed/v_1_0_0/serializer.py search_query/ebscohost/v_1_0_0/parser.py search_query/ebscohost/v_1_0_0/translator.py search_query/ebscohost/v_1_0_0/serializer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb1154e02c832a96b1d7f568170f4b