### PR TITLE
feat(wos): add version 0.0.0 supporting deprecated fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 - Introduced versioned parser, serializer, and translator dispatchers.
 - Added upgrade pipeline and CLI command.
 - Added `deprecated-syntax` linter warning (`LINT_2001`).
+- Added Web of Science parser version `0.0.0` with support for field tags later
+  marked as deprecated.
 
 ## Release 0.12.0
 

--- a/search_query/wos/v_0_0_0/__init__.py
+++ b/search_query/wos/v_0_0_0/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+"""WoS v0.0.0."""
+
+__author__ = """Gerit Wagner"""
+__email__ = "gerit.wagner@hec.ca"

--- a/search_query/wos/v_0_0_0/parser.py
+++ b/search_query/wos/v_0_0_0/parser.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Versioned Web of Science parser wrappers."""
+from __future__ import annotations
+
+import re
+import typing
+
+from search_query.wos.linter import WOSQueryListLinter
+from search_query.wos.linter import WOSQueryStringLinter
+from search_query.wos.parser import WOSListParser
+from search_query.wos.parser import WOSParser
+from search_query.query import Query
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
+
+
+class WOSQueryStringLinter_v0_0_0(WOSQueryStringLinter):
+    """Linter for WOS queries supporting deprecated fields."""
+
+    VERSION = "0.0.0"
+    VALID_fieldS_REGEX = re.compile(r"^[A-Za-z]{2,3}=$", re.IGNORECASE)
+
+    def check_deprecated_field_tags(self, query: Query) -> None:  # pragma: no cover - simple override
+        """Allow field tags that were deprecated in later versions."""
+
+        return
+
+
+class WOSParser_v0_0_0(WOSParser):
+    """Web of Science parser for version 0.0.0."""
+
+    VERSION = "0.0.0"
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        query_str: str,
+        *,
+        field_general: str = "",
+        offset: typing.Optional[dict] = None,
+        original_str: typing.Optional[str] = None,
+        silent: bool = False,
+    ) -> None:
+        super().__init__(
+            query_str,
+            field_general=field_general,
+            offset=offset,
+            original_str=original_str,
+            silent=silent,
+        )
+        self.linter = WOSQueryStringLinter_v0_0_0(
+            query_str=query_str, original_str=original_str, silent=silent
+        )
+
+
+class WOSListParser_v0_0_0(WOSListParser):
+    """Web of Science list parser for version 0.0.0."""
+
+    VERSION = "0.0.0"
+
+    def __init__(self, query_list: str, *, field_general: str = "") -> None:
+        super().__init__(query_list=query_list, field_general=field_general)
+        self.parser_class = WOSParser_v0_0_0
+        self.linter = WOSQueryListLinter(
+            parser=self,
+            string_parser_class=WOSParser_v0_0_0,
+            original_query_str=query_list,
+        )
+
+
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register these parsers with the ``registry``."""
+
+    registry.register_parser_string(platform, version, WOSParser_v0_0_0)
+    registry.register_parser_list(platform, version, WOSListParser_v0_0_0)

--- a/search_query/wos/v_0_0_0/serializer.py
+++ b/search_query/wos/v_0_0_0/serializer.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Web of Science serializer for version 0.0.0."""
+from __future__ import annotations
+
+import typing
+
+from search_query.wos.serializer import WOSQuerySerializer
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
+
+
+# pylint: disable=too-few-public-methods
+class WOSSerializer_v0_0_0(WOSQuerySerializer):
+    """Web of Science serializer for version 0.0.0."""
+
+    VERSION = "0.0.0"
+
+
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this serializer with the ``registry``."""
+
+    registry.register_serializer_string(platform, version, WOSSerializer_v0_0_0)
+    registry.register_serializer_list(platform, version, WOSSerializer_v0_0_0)

--- a/search_query/wos/v_0_0_0/translator.py
+++ b/search_query/wos/v_0_0_0/translator.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Web of Science translator for version 0.0.0."""
+from __future__ import annotations
+
+import typing
+
+from search_query.wos.translator import WOSTranslator
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from search_query.registry import Registry
+
+
+class WOSTranslator_v0_0_0(WOSTranslator):
+    """Translator for WOS queries."""
+
+    VERSION = "0.0.0"
+
+
+def register(registry: Registry, *, platform: str, version: str) -> None:
+    """Register this translator with the ``registry``."""
+
+    registry.register_translator(platform, version, WOSTranslator_v0_0_0)

--- a/test/wos/test_wos_parser_v_0_0_0.py
+++ b/test/wos/test_wos_parser_v_0_0_0.py
@@ -1,0 +1,9 @@
+"""Tests for WOSParser_v0_0_0"""
+
+from search_query.wos.v_0_0_0.parser import WOSParser_v0_0_0
+
+
+def test_deprecated_fields_supported() -> None:
+    parser = WOSParser_v0_0_0("FN=example AND DE=test")
+    parser.parse()
+    assert parser.linter.messages == []


### PR DESCRIPTION
## Summary
- add Web of Science v0.0.0 parser, serializer, and translator
- allow previously deprecated WOS field tags in v0.0.0
- document new version and cover with basic test

## Testing
- `uv run pre-commit run --files CHANGELOG.md search_query/wos/v_0_0_0/__init__.py search_query/wos/v_0_0_0/parser.py search_query/wos/v_0_0_0/serializer.py search_query/wos/v_0_0_0/translator.py test/wos/test_wos_parser_v_0_0_0.py` *(failed: Failed to fetch: `https://pypi.org/simple/pytest/`)*
- `uv run pytest test/wos/test_wos_parser_v_0_0_0.py` *(failed: Failed to fetch: `https://pypi.org/simple/sphinxcontrib-datatemplates/`)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3388674c832a919667bd298b8454