### PR TITLE
feat: allow ignoring failing linters during upgrades

### DIFF
--- a/search_query/ebscohost/linter.py
+++ b/search_query/ebscohost/linter.py
@@ -67,8 +67,14 @@ class EBSCOQueryStringLinter(QueryStringLinter):
         *,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
-        super().__init__(query_str=query_str, original_str=original_str, silent=silent)
+        super().__init__(
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def validate_tokens(
         self,
@@ -363,10 +369,15 @@ class EBSCOListLinter(QueryListLinter):
         self,
         parser: EBSCOListParser,
         string_parser_class: typing.Type[QueryStringParser],
-    ):
+        ignore_failing_linter: bool = False,
+    ) -> None:
         self.parser: EBSCOListParser = parser
         self.string_parser_class = string_parser_class
-        super().__init__(parser, string_parser_class)
+        super().__init__(
+            parser,
+            string_parser_class,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def validate_tokens(self) -> None:
         """Validate token list"""

--- a/search_query/ebscohost/parser.py
+++ b/search_query/ebscohost/parser.py
@@ -55,6 +55,7 @@ class EBSCOParser(QueryStringParser):
         offset: typing.Optional[dict] = None,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         """Initialize the parser."""
         super().__init__(
@@ -62,9 +63,14 @@ class EBSCOParser(QueryStringParser):
             field_general=field_general,
             offset=offset,
             original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.linter = EBSCOQueryStringLinter(
-            query_str=query_str, original_str=original_str, silent=silent
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
     def combine_subsequent_tokens(self) -> None:
@@ -428,13 +434,19 @@ class EBSCOListParser(QueryListParser):
         self,
         query_list: str,
         field_general: str = "",
+        ignore_failing_linter: bool = False,
     ) -> None:
         super().__init__(
             query_list=query_list,
             parser_class=EBSCOParser,
             field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
         )
-        self.linter = EBSCOListLinter(parser=self, string_parser_class=EBSCOParser)
+        self.linter = EBSCOListLinter(
+            parser=self,
+            string_parser_class=EBSCOParser,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def parse(self) -> Query:
         """Parse EBSCO list query."""
@@ -455,6 +467,7 @@ class EBSCOListParser(QueryListParser):
             field_general=self.field_general,
             offset=offset,
             silent=True,
+            ignore_failing_linter=self.ignore_failing_linter,
         )
         try:
             query = query_parser.parse()

--- a/search_query/ebscohost/v_1_0_0/parser.py
+++ b/search_query/ebscohost/v_1_0_0/parser.py
@@ -25,10 +25,24 @@ class EBSCOListParser_v1_0_0(EBSCOListParser):
 
     VERSION = "1.0.0"
 
-    def __init__(self, query_list: str, *, field_general: str = "") -> None:
-        super().__init__(query_list=query_list, field_general=field_general)
+    def __init__(
+        self,
+        query_list: str,
+        *,
+        field_general: str = "",
+        ignore_failing_linter: bool = False,
+    ) -> None:
+        super().__init__(
+            query_list=query_list,
+            field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
+        )
         self.parser_class = EBSCOParser_v1_0_0
-        self.linter = EBSCOListLinter(self, EBSCOParser_v1_0_0)
+        self.linter = EBSCOListLinter(
+            parser=self,
+            string_parser_class=EBSCOParser_v1_0_0,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
 
 def register(registry: Registry, *, platform: str, version: str) -> None:

--- a/search_query/generic/linter.py
+++ b/search_query/generic/linter.py
@@ -28,8 +28,15 @@ class GenericLinter(QueryStringLinter):
 
     VALID_fieldS_REGEX = re.compile(r"\b(?:" + "|".join(sorted(field_codes)) + r")\b")
 
-    def __init__(self, query_str: str = "") -> None:
-        super().__init__(query_str=query_str)
+    def __init__(
+        self,
+        query_str: str = "",
+        *,
+        ignore_failing_linter: bool = False,
+    ) -> None:
+        super().__init__(
+            query_str=query_str, ignore_failing_linter=ignore_failing_linter
+        )
 
     def syntax_str_to_generic_field_set(self, field_value: str) -> set:
         """Translate a search field"""

--- a/search_query/linter_base.py
+++ b/search_query/linter_base.py
@@ -57,6 +57,7 @@ class QueryStringLinter:
         *,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         self.tokens: typing.List[Token] = []
 
@@ -72,6 +73,7 @@ class QueryStringLinter:
         self.original_str = original_str or query_str
         # silent: primarily for ListParsers
         self.silent = silent
+        self.ignore_failing_linter = ignore_failing_linter
 
     def add_message(
         self,
@@ -156,7 +158,13 @@ class QueryStringLinter:
         self.print_messages()
 
         if self.has_fatal_errors():
-            raise QuerySyntaxError(self)
+            if self.ignore_failing_linter:
+                print(
+                    f"{Colors.ORANGE}Warning{Colors.END}: "
+                    "Ignoring fatal linter errors."
+                )
+            else:
+                raise QuerySyntaxError(self)
 
     def has_fatal_errors(self) -> bool:
         """Check if there are any fatal errors."""
@@ -1481,12 +1489,14 @@ class QueryListLinter:
         parser: search_query.parser_base.QueryListParser,
         string_parser_class: typing.Type[search_query.parser_base.QueryStringParser],
         original_query_str: str = "",
-    ):
+        ignore_failing_linter: bool = False,
+    ) -> None:
         self.parser = parser
         self.messages: dict = {}
         self.string_parser_class = string_parser_class
         self.last_read_index: typing.Dict[int, int] = {}
         self.original_query_str = original_query_str
+        self.ignore_failing_linter = ignore_failing_linter
 
     # pylint: disable=too-many-arguments
     def add_message(
@@ -1579,7 +1589,13 @@ class QueryListLinter:
         self.print_messages()
 
         if self.has_fatal_errors():
-            raise ListQuerySyntaxError(self)
+            if self.ignore_failing_linter:
+                print(
+                    f"{Colors.ORANGE}Warning{Colors.END}: "
+                    "Ignoring fatal linter errors."
+                )
+            else:
+                raise ListQuerySyntaxError(self)
 
 
 def _print_bullet_message(message: str, indent: int = 2, bullet: str = "-") -> None:

--- a/search_query/parser_base.py
+++ b/search_query/parser_base.py
@@ -37,12 +37,14 @@ class QueryStringParser(ABC):
         offset: typing.Optional[dict] = None,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         self.query_str = query_str
         self.tokens: list = []
         # The external fields (in the JSON file: "field")
         self.field_general = field_general
         self.silent = silent
+        self.ignore_failing_linter = ignore_failing_linter
         self.offset = offset or {}
         self.original_str = original_str or query_str
 
@@ -210,12 +212,14 @@ class QueryListParser:
         *,
         parser_class: type[QueryStringParser],
         field_general: str,
+        ignore_failing_linter: bool = False,
     ) -> None:
         # Remove leading whitespaces/newlines from the query_list
         # to ensure correct token positions
         self.query_list = query_list.lstrip()
         self.parser_class = parser_class
         self.field_general = field_general
+        self.ignore_failing_linter = ignore_failing_linter
         self.query_dict: dict = {}
 
     def tokenize_list(self) -> None:

--- a/search_query/pubmed/linter.py
+++ b/search_query/pubmed/linter.py
@@ -79,8 +79,14 @@ class PubmedQueryStringLinter(QueryStringLinter):
         *,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
-        super().__init__(query_str=query_str, original_str=original_str, silent=silent)
+        super().__init__(
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def validate_tokens(
         self,
@@ -595,10 +601,15 @@ class PubmedQueryListLinter(QueryListLinter):
         self,
         parser: PubmedListParser,
         string_parser_class: typing.Type[QueryStringParser],
-    ):
+        ignore_failing_linter: bool = False,
+    ) -> None:
         self.parser: PubmedListParser = parser
         self.string_parser_class = string_parser_class
-        super().__init__(parser, string_parser_class)
+        super().__init__(
+            parser,
+            string_parser_class,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def validate_tokens(self) -> None:
         """Validate token list"""

--- a/search_query/pubmed/parser.py
+++ b/search_query/pubmed/parser.py
@@ -52,6 +52,7 @@ class PubmedParser(QueryStringParser):
         offset: typing.Optional[dict] = None,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         """Initialize the parser."""
         super().__init__(
@@ -59,9 +60,14 @@ class PubmedParser(QueryStringParser):
             field_general=field_general,
             offset=offset,
             original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.linter = PubmedQueryStringLinter(
-            query_str=query_str, original_str=original_str, silent=silent
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
     def tokenize(self) -> None:
@@ -297,13 +303,19 @@ class PubmedListParser(QueryListParser):
         query_list: str,
         *,
         field_general: str = "",
+        ignore_failing_linter: bool = False,
     ) -> None:
         super().__init__(
             query_list,
             parser_class=PubmedParser,
             field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
         )
-        self.linter = PubmedQueryListLinter(self, PubmedParser)
+        self.linter = PubmedQueryListLinter(
+            self,
+            PubmedParser,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def parse(self) -> Query:
         """Parse the query in list format."""
@@ -320,6 +332,7 @@ class PubmedListParser(QueryListParser):
             field_general=self.field_general,
             offset=offset,
             silent=True,
+            ignore_failing_linter=self.ignore_failing_linter,
         )
         try:
             query = query_parser.parse()

--- a/search_query/pubmed/v_1_0_0/parser.py
+++ b/search_query/pubmed/v_1_0_0/parser.py
@@ -23,11 +23,25 @@ class PubMedListParser_v1_0_0(PubmedListParser):
 
     VERSION = "1.0.0"
 
-    def __init__(self, query_list: str, *, field_general: str = "") -> None:
-        super().__init__(query_list=query_list, field_general=field_general)
+    def __init__(
+        self,
+        query_list: str,
+        *,
+        field_general: str = "",
+        ignore_failing_linter: bool = False,
+    ) -> None:
+        super().__init__(
+            query_list=query_list,
+            field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
+        )
         # Ensure versioned parser and linter are used
         self.parser_class = PubMedParser_v1_0_0
-        self.linter = PubmedQueryListLinter(self, PubMedParser_v1_0_0)
+        self.linter = PubmedQueryListLinter(
+            self,
+            PubMedParser_v1_0_0,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
 
 def register(registry: Registry, *, platform: str, version: str) -> None:

--- a/search_query/upgrade.py
+++ b/search_query/upgrade.py
@@ -42,7 +42,7 @@ def upgrade_query(
 
     # 1) Parse source query string into a query object.
     parser_cls = PARSERS[platform][version_current]
-    source_query = parser_cls(query_str).parse()
+    source_query = parser_cls(query_str, ignore_failing_linter=True).parse()
 
     # 2) Translate platform/version-specific query → generic query (IR).
     translator_cls_current = TRANSLATORS[platform][version_current]
@@ -58,6 +58,8 @@ def upgrade_query(
 
     # 5) Safety check: re-parse in the target version to validate output.
     parser_cls_target = PARSERS[platform][version_target]
-    parser_cls_target(upgraded_query_str).parse()
+    parser_cls_target(
+        upgraded_query_str, ignore_failing_linter=True
+    ).parse()
 
     return upgraded_query_str

--- a/search_query/wos/linter.py
+++ b/search_query/wos/linter.py
@@ -79,8 +79,14 @@ class WOSQueryStringLinter(QueryStringLinter):
         *,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
-        super().__init__(query_str=query_str, original_str=original_str, silent=silent)
+        super().__init__(
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
     def validate_tokens(
         self,
@@ -615,11 +621,13 @@ class WOSQueryListLinter(QueryListLinter):
         parser: search_query.wos.parser.WOSListParser,
         string_parser_class: typing.Type[search_query.wos.parser.WOSParser],
         original_query_str: str = "",
-    ):
+        ignore_failing_linter: bool = False,
+    ) -> None:
         super().__init__(
             parser=parser,
             string_parser_class=string_parser_class,
             original_query_str=original_query_str,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.messages: dict = {}
 

--- a/search_query/wos/parser.py
+++ b/search_query/wos/parser.py
@@ -64,6 +64,7 @@ class WOSParser(QueryStringParser):
         offset: typing.Optional[dict] = None,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         """Initialize the parser."""
         super().__init__(
@@ -71,9 +72,14 @@ class WOSParser(QueryStringParser):
             field_general=field_general,
             offset=offset,
             original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.linter = WOSQueryStringLinter(
-            query_str=query_str, original_str=original_str, silent=silent
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
     def tokenize(self) -> None:
@@ -377,16 +383,23 @@ class WOSParser(QueryStringParser):
 class WOSListParser(QueryListParser):
     """Parser for Web-of-Science (list format) queries."""
 
-    def __init__(self, query_list: str, field_general: str = "") -> None:
+    def __init__(
+        self,
+        query_list: str,
+        field_general: str = "",
+        ignore_failing_linter: bool = False,
+    ) -> None:
         super().__init__(
             query_list=query_list,
             parser_class=WOSParser,
             field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.linter = WOSQueryListLinter(
             parser=self,
             string_parser_class=WOSParser,
             original_query_str=query_list,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
     def parse(self) -> Query:
@@ -405,6 +418,7 @@ class WOSListParser(QueryListParser):
             field_general=self.field_general,
             offset=offset,
             silent=True,
+            ignore_failing_linter=self.ignore_failing_linter,
         )
         try:
             query = query_parser.parse()

--- a/search_query/wos/v_0_0_0/parser.py
+++ b/search_query/wos/v_0_0_0/parser.py
@@ -41,6 +41,7 @@ class WOSParser_v0_0_0(WOSParser):
         offset: typing.Optional[dict] = None,
         original_str: typing.Optional[str] = None,
         silent: bool = False,
+        ignore_failing_linter: bool = False,
     ) -> None:
         super().__init__(
             query_str,
@@ -48,9 +49,13 @@ class WOSParser_v0_0_0(WOSParser):
             offset=offset,
             original_str=original_str,
             silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
         self.linter = WOSQueryStringLinter_v0_0_0(
-            query_str=query_str, original_str=original_str, silent=silent
+            query_str=query_str,
+            original_str=original_str,
+            silent=silent,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
 
@@ -59,13 +64,24 @@ class WOSListParser_v0_0_0(WOSListParser):
 
     VERSION = "0.0.0"
 
-    def __init__(self, query_list: str, *, field_general: str = "") -> None:
-        super().__init__(query_list=query_list, field_general=field_general)
+    def __init__(
+        self,
+        query_list: str,
+        *,
+        field_general: str = "",
+        ignore_failing_linter: bool = False,
+    ) -> None:
+        super().__init__(
+            query_list=query_list,
+            field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
+        )
         self.parser_class = WOSParser_v0_0_0
         self.linter = WOSQueryListLinter(
             parser=self,
             string_parser_class=WOSParser_v0_0_0,
             original_query_str=query_list,
+            ignore_failing_linter=ignore_failing_linter,
         )
 
 

--- a/search_query/wos/v_1_0_0/parser.py
+++ b/search_query/wos/v_1_0_0/parser.py
@@ -23,10 +23,25 @@ class WOSListParser_v1_0_0(WOSListParser):
 
     VERSION = "1.0.0"
 
-    def __init__(self, query_list: str, *, field_general: str = "") -> None:
-        super().__init__(query_list=query_list, field_general=field_general)
+    def __init__(
+        self,
+        query_list: str,
+        *,
+        field_general: str = "",
+        ignore_failing_linter: bool = False,
+    ) -> None:
+        super().__init__(
+            query_list=query_list,
+            field_general=field_general,
+            ignore_failing_linter=ignore_failing_linter,
+        )
         self.parser_class = WOSParser_v1_0_0
-        self.linter = WOSQueryListLinter(self, WOSParser_v1_0_0)
+        self.linter = WOSQueryListLinter(
+            parser=self,
+            string_parser_class=WOSParser_v1_0_0,
+            original_query_str=query_list,
+            ignore_failing_linter=ignore_failing_linter,
+        )
 
 
 def register(registry: Registry, *, platform: str, version: str) -> None:


### PR DESCRIPTION
## Summary
- add `ignore_failing_linter` flag to linter base and platform linters
- forward flag from parsers and warn instead of raising when linters fail
- invoke linters regardless of flag so users see non-fatal diagnostics

## Testing
- `pip install hatchling` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `PYTHONPATH=$PWD pytest` *(fails: PackageNotFoundError: No package metadata was found for search_query)*

------
https://chatgpt.com/codex/tasks/task_e_68c0111ebb60832a8d2bd6fc3e7322cc