### PR TITLE
docs: use sentence case for headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# Change Log
+# Changelog
 All notable changes to this project will be documented in this file.
 
 ## Unreleased

--- a/docs/source/dev_docs/linter_development.rst
+++ b/docs/source/dev_docs/linter_development.rst
@@ -6,7 +6,7 @@ They analyze token sequences, syntax, search fields, and operator use to identif
 errors or ambiguities and print meaningful messages (documented in the `messages <../messages/errors_index.html>`_ section).
 Each platform implements its own linter, which interhits from the base class `linter_base.py`. Linters are used in the parser methods.
 
-Base Classes
+Base classes
 ------------
 Use the appropriate base class when developing a new linter:
 
@@ -16,7 +16,7 @@ Use the appropriate base class when developing a new linter:
 Each linter must override the `validate_tokens()` method and the `validate_query_tree()`.
 `validate_tokens()` is called when the query is parsed, and `validate_query_tree()` is called when the query tree is built (i.e., at the end of the parsing process **and** when the query is constructed programmatically).
 
-Best Practices
+Best practices
 --------------
 - **Use standardized linter messages** defined in `constants.QueryErrorCode`.
 - **Add details** in messages for guidance (e.g., invalid format, missing logic).

--- a/docs/source/dev_docs/parser_development.rst
+++ b/docs/source/dev_docs/parser_development.rst
@@ -18,7 +18,7 @@ When introducing a new parser version, copy the previous versioned
 directory, adjust the implementation, and register the version in the
 ``PARSERS`` dictionary.
 
-1. Inherit from Base Classes
+1. Inherit from base classes
 -----------------------------------
 
 Use the provided base classes, which provide a number of utility methods:
@@ -107,8 +107,8 @@ Check whether ``SearchFields`` can be created for nested queries (e.g., ``TI=(eH
    :language: python
 
 
-List Format Support
------------------------------------
+List format support
+----------------------------------
 
 Implement  ``QueryListParser`` to handle numbered sub-queries and references like ``#1 AND #2``.
 

--- a/docs/source/dev_docs/tests.rst
+++ b/docs/source/dev_docs/tests.rst
@@ -10,7 +10,7 @@ To run all tests:
 
     pytest test
 
-Test Types
+Test types
 ----------
 
 1. **Tokenization Tests**

--- a/docs/source/dev_docs/translator_development.rst
+++ b/docs/source/dev_docs/translator_development.rst
@@ -8,8 +8,8 @@ Translators convert between:
 
 Each translator implements `QueryTranslator`, the abstract base class from ``translator_base.py``.
 
-Translator Responsibilities
----------------------------
+Translator responsibilities
+--------------------------
 
 A translator must implement the following two class methods:
 
@@ -35,8 +35,8 @@ specified platform.
 To introduce a new translator version, duplicate the previous versioned directory,
 update the implementation as needed, and register the new version in the ``TRANSLATORS`` dictionary.
 
-Utility Methods Provided
-------------------------
+Utility methods provided
+-----------------------
 
 The base class (`QueryTranslator`) provides the following utilities:
 
@@ -47,8 +47,8 @@ The base class (`QueryTranslator`) provides the following utilities:
 - ``move_fields_to_operator(query)``:
   If all children have the same field, moves it to the parent node.
 
-Search Field Mapping
---------------------
+Search field mapping
+-------------------
 
 Field mapping is expected to be defined in a `constants_<source>.py` file and typically includes:
 
@@ -61,15 +61,15 @@ Each translator should:
 2. Handle combined fields (e.g., `[tiab]` in PubMed)
 3. Optionally restructure the query for consistency
 
-Code Skeleton
--------------
+Code skeleton
+------------
 
 .. literalinclude:: translator_skeleton.py
    :language: python
 
 
-Advanced Features
------------------
+Advanced features
+----------------
 
 Some translators include advanced restructuring logic:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,8 +113,8 @@ A Jupyter Notebook demo (hosted on Binder) is available here:
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/CoLRev-Environment/search-query/HEAD?labpath=docs%2Fsource%2Fdemo.ipynb
 
-Functional Overview
-=======================
+Functional overview
+======================
 
 The search-query package supports the entire lifecycle of academic search query management.
 Below is a high-level overview of the core functionalities:

--- a/docs/source/lint/errors_index.rst
+++ b/docs/source/lint/errors_index.rst
@@ -98,7 +98,7 @@ Database errors: Web of Science
 
    WOS_0012
 
-Database errors: EBSCOHost
+Database errors: EBSCOhost
 --------------------------
 
 .. toctree::

--- a/docs/source/load.rst
+++ b/docs/source/load.rst
@@ -5,7 +5,7 @@ Load
 
 Queries can be loaded from strings/files, defined as objects, or retrieved from the internal database.
 
-String/File
+String/file
 -------------------------
 
 Search-query can parse queries from strings and JSON query files.

--- a/docs/source/platforms/ebsco.rst
+++ b/docs/source/platforms/ebsco.rst
@@ -1,23 +1,23 @@
 .. _ebsco:
 
-EBSCOHost
+EBSCOhost
 =========
 
-EBSCOHost provides access to a wide range of academic databases across disciplines, including business, education, psychology, and health sciences.
+EBSCOhost provides access to a wide range of academic databases across disciplines, including business, education, psychology, and health sciences.
 
-Run a Query
+Run a query
 -----------
 
-EBSCOHost queries can be constructed using the standard `EBSCOHost advanced search interface <https://search.ebscohost.com/>`_ (requires institutional access).
+EBSCOhost queries can be constructed using the standard `EBSCOhost advanced search interface <https://search.ebscohost.com/>`_ (requires institutional access).
 
 When working with `search-query`, extract the **Search terms** from the **Search History** panel or persistent URL for use as the `search_string`.
 
-EBSCOHost query syntax includes field tags such as `AB`, `TI`, `SU`, etc. These should be included directly in the `search_string`.
+EBSCOhost query syntax includes field tags such as `AB`, `TI`, `SU`, etc. These should be included directly in the `search_string`.
 
-Store a Query
+Store a query
 -------------
 
-When storing an EBSCOHost query in a `.json` file or as a string:
+When storing an EBSCOhost query in a `.json` file or as a string:
 
 - Use the **Search History** or the **Search Terms** as the `search_string`.
 
@@ -29,8 +29,8 @@ When storing an EBSCOHost query in a `.json` file or as a string:
 
    Do not use the **persistent link feature**.
 
-List Query Format
---------------------
+List query format
+-----------------
 
 EBSCOhost supports building **multi-line queries** where individual components are defined as numbered search lines and later combined using references like ``S1 AND S2``. This method is often used in advanced or expert search modes.
 
@@ -46,7 +46,7 @@ List queries should be formatted as follows:
 Each numbered item defines a part of the query using EBSCOhost's field syntax. Later lines can combine them using boolean operators like ``AND``, ``OR``, or ``NOT``, allowing for structured, transparent query design.
 
 
-Best Practices and Recommendations
+Best practices and recommendations
 ----------------------------------
 
 - **Use field tags** (e.g., `AB`, `TI`) explicitly in the query string.

--- a/docs/source/platforms/pubmed.rst
+++ b/docs/source/platforms/pubmed.rst
@@ -6,7 +6,7 @@ PubMed
 
 PubMed is a free resource supporting the search and retrieval of biomedical and life sciences literature.
 
-Run a Query
+Run a query
 -----------
 
 Queries can be entered using either:
@@ -20,7 +20,7 @@ These interfaces are functionally equivalent for the purposes of `search-query`.
 
    Include field tags explicitly in the `search_string`. Leave the `general_field` empty.
 
-Store a Query
+Store a query
 -------------
 
 When storing a PubMed query in a `.json` file or as a string:
@@ -28,8 +28,8 @@ When storing a PubMed query in a `.json` file or as a string:
 - Use the content of the **Query box** or **Search details** section as the `search_string`.
 - Leave the `general_field` empty.
 
-List Query Format
---------------------
+List query format
+-----------------
 
 PubMed allows combining previous searches using the search history panel. These list-based queries can reference earlier searches using numbered identifiers (e.g., `#1 OR #2`). In the advanced search interface, such combinations can also be created via the **“Add”** button. List queries are supported by `search-query` parsers.
 
@@ -42,7 +42,7 @@ List queries should be formatted as follows:
        "general_field": ""
    }
 
-Best Practices and Recommendations
+Best practices and recommendations
 ----------------------------------
 
 The advanced PubMed interface offers a dropdown for search fields such as `[Title/Abstract]`, `[Author]`, etc. When using this feature:

--- a/docs/source/platforms/syntax_upgrade.rst
+++ b/docs/source/platforms/syntax_upgrade.rst
@@ -1,6 +1,6 @@
 .. _upgrade:
 
-Syntax Upgrades
+Syntax upgrades
 ===============
 
 The ``search-query`` package upgrades **database-specific queries** from one *database syntax version* to another.
@@ -19,7 +19,7 @@ By default, omission of the ``--to`` option or setting it to ``latest`` upgrades
 A particular target version can also be specified using ``--to <version>``, but upgrading to the latest version (by omitting ``--to``) is generally recommended.
 The upgraded query will be written back to the file (or another location if specified with ``--output``).
 
-Versioning Policy
+Versioning policy
 -----------------
 
 .. note::
@@ -58,8 +58,8 @@ They do **not** require an upgrade of stored queries and therefore do not result
    Syntax versions start with 1.0 as of 2025-09-01. Previous versions will not be
    explored systematically and version 0.0 may be used as a placeholder for all earlier syntax.
 
-Observability of Syntax Versions
---------------------------------
+Observability of syntax versions
+---------------------------------
 
 Observability of *historic* versions is often limited because providers rarely
 publish precise, comprehensive changelogs of syntax rules.
@@ -72,8 +72,8 @@ As a result:
 - When a significant breaking change is detected, the package encodes it as a new MAJOR version and
   provides **upgrade** paths via the IR.
 
-How Upgrades Work Internally
------------------------------
+How upgrades work internally
+----------------------------
 
 Even though only the CLI is called, the following procedure happens under the hood:
 

--- a/docs/source/platforms/wos.rst
+++ b/docs/source/platforms/wos.rst
@@ -5,7 +5,7 @@ Web of Science
 
 Web of Science (WoS) is a multidisciplinary citation database that supports structured search queries with field tags and Boolean operators.
 
-Run a Query
+Run a query
 -----------
 
 Queries in Web of Science can be constructed using:
@@ -21,7 +21,7 @@ Web of Science supports structured queries using field tags such as `TS=` (Topic
 
    Include field tags explicitly in the `search_string`. Leave the `general_field` empty.
 
-Store a Query
+Store a query
 -------------
 
 When storing a Web of Science query:
@@ -34,8 +34,8 @@ Example::
    (TS="digital health") AND (TS="privacy")
 
 
-List Query Format
----------------------
+List query format
+-----------------
 
 Web of Science allows the construction of **complex queries** by combining previously defined search sets using numbered references (e.g., ``#1 AND #2``). This list-based approach is commonly used in systematic searches where multiple search lines are logically combined.
 
@@ -52,7 +52,7 @@ List queries should be formatted as follows:
 
 Each numbered line represents an individual query component, and later lines can combine previous results using logical operators like ``AND``, ``OR``, or ``NOT``.
 
-Best Practices and Recommendations
+Best practices and recommendations
 ----------------------------------
 
 - Prefer **Advanced Search** for reproducible and structured queries.

--- a/docs/source/query_database/index.rst
+++ b/docs/source/query_database/index.rst
@@ -9,7 +9,7 @@ Query database
          ("Title", "title"),
          ("Keywords", "keywords")],
         data,
-        title='Available Predefined Queries',
+        title='Available predefined queries',
         columns=[20, 6, 20, 20]
     ) }}
 

--- a/docs/source/query_database/queries/ais_senior_scholars_basket.rst
+++ b/docs/source/query_database/queries/ais_senior_scholars_basket.rst
@@ -1,4 +1,4 @@
-Filter: AIS Senior Scholars Basket
+Filter: AIS senior scholars basket
 ==================================
 
 **Identifier**: ``ais_senior_scholars_basket``
@@ -26,7 +26,7 @@ Load
     # SO=("European Journal of Information Systems" OR "Information Systems Journal" O...
 
 
-Search String
+Search string
 -------------
 
 .. raw:: html

--- a/docs/source/query_database/queries/ais_senior_scholars_list_of_premier_journals.rst
+++ b/docs/source/query_database/queries/ais_senior_scholars_list_of_premier_journals.rst
@@ -1,4 +1,4 @@
-Filter: AIS Senior Scholars List of Premier Journals
+Filter: AIS senior scholars list of premier journals
 ====================================================
 
 **Identifier**: ``ais_senior_scholars_list_of_premier_journals``
@@ -26,7 +26,7 @@ Load
     # SO=("European Journal of Information Systems" OR "Information Systems Journal" O...
 
 
-Search String
+Search string
 -------------
 
 .. raw:: html

--- a/docs/source/query_database/queries/blocks_bmi_343.rst
+++ b/docs/source/query_database/queries/blocks_bmi_343.rst
@@ -1,4 +1,4 @@
-Block: Treatment as usual
+Block: treatment as usual
 =========================
 
 **Identifier**: ``blocks_bmi_343``
@@ -26,7 +26,7 @@ Load
     # (treatment*[tiab] AND usual[tiab]) OR (standard[tiab] AND care[tiab]) OR (standa...
 
 
-Search String
+Search string
 -------------
 
 .. raw:: html

--- a/docs/source/query_database/queries/journals_ft50.rst
+++ b/docs/source/query_database/queries/journals_ft50.rst
@@ -26,7 +26,7 @@ Load
     # SO=("Academy of Management Journal" OR "Academy of Management Review" OR "Accoun...
 
 
-Search String
+Search string
 -------------
 
 .. raw:: html

--- a/docs/source/query_database/submit.rst
+++ b/docs/source/query_database/submit.rst
@@ -1,5 +1,5 @@
-Submit a Query
-===========================
+Submit a query
+==========================
 
 Contributions of queries and predefined query filters to the `search-query` database are welcome.
 
@@ -17,7 +17,7 @@ To submit a query:
 
 Once the PR is merged, the query will be **automatically included and rendered** in the documentation.
 
-JSON Structure
+JSON structure
 ---------------------------
 
 The `.json` file should follow this structure:


### PR DESCRIPTION
## Summary
- convert documentation headings to sentence case across guides and references
- rename Change Log to Changelog

## Testing
- `pre-commit run --files $(git ls-files -m)` *(fails: command not found)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement hatchling)*
- `pytest test` *(fails: ModuleNotFoundError: No module named 'search_query')*

------
https://chatgpt.com/codex/tasks/task_e_68c07920bffc832a9d759908e9696f5a