### PR TITLE
Warn when query terms use escaped Unicode sequences

### DIFF
--- a/search_query/constants.py
+++ b/search_query/constants.py
@@ -807,6 +807,27 @@ search-query upgrade search_query.json --to 2.0.0
     comput*""",
     )
 
+    UNICODE_ESCAPE_SEQUENCE = (
+        "QUALITY_0007",
+        "unicode-escape-sequence",
+        "Search term contains escaped Unicode sequence",
+        """
+**Problematic query**:
+
+.. code-block:: text
+
+    "p\\u00e9tanque"[tiab]
+
+**Recommended query**:
+
+.. code-block:: text
+
+    "pétanque"[tiab]
+
+**Typical fix**: Replace escaped Unicode sequences with their UTF-8 characters before executing the query.
+""",
+    )
+
     # -------------------------------------------------------
     # Structural
     # -------------------------------------------------------

--- a/search_query/ebscohost/linter.py
+++ b/search_query/ebscohost/linter.py
@@ -101,6 +101,7 @@ class EBSCOQueryStringLinter(QueryStringLinter):
             return self.tokens
 
         self.check_general_field()
+        self.check_unicode_escape_sequences_in_terms()
 
         return self.tokens
 

--- a/search_query/pubmed/linter.py
+++ b/search_query/pubmed/linter.py
@@ -118,6 +118,7 @@ class PubmedQueryStringLinter(QueryStringLinter):
         self.check_boolean_operator_readability()
 
         self.check_invalid_proximity_operator()
+        self.check_unicode_escape_sequences_in_terms()
         return self.tokens
 
     def check_invalid_syntax(self) -> None:

--- a/search_query/wos/linter.py
+++ b/search_query/wos/linter.py
@@ -120,6 +120,7 @@ class WOSQueryStringLinter(QueryStringLinter):
         self.check_missing_fields()
 
         self.check_implicit_near()
+        self.check_unicode_escape_sequences_in_terms()
         return self.tokens
 
     def check_invalid_syntax(self) -> None:

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -177,3 +177,33 @@ def test_check_invalid_characters_in_term_query() -> None:
             "details": "Invalid character '#' in search term 'digitalizat#ion'",
         }
     ]
+
+
+def test_check_unicode_escape_sequences_in_terms() -> None:
+    linter = QueryStringLinter('"p\\u00e9tanque"[tiab]')  # type: ignore
+    linter.tokens = [
+        Token(
+            type=TokenTypes.TERM,
+            value='"p\\u00e9tanque"',
+            position=(0, 15),
+        )
+    ]
+
+    linter.check_unicode_escape_sequences_in_terms()
+
+    term = '"p\\u00e9tanque"'
+    expected_details = (
+        "Escaped Unicode sequence '\\u00e9' in search term '{term}'. "
+        "Use the UTF-8 character 'é' instead."
+    ).format(term=term)
+
+    assert linter.messages == [
+        {
+            "code": "QUALITY_0007",
+            "label": "unicode-escape-sequence",
+            "message": "Search term contains escaped Unicode sequence",
+            "is_fatal": False,
+            "position": [(2, 8)],
+            "details": expected_details,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add a QUALITY linter code that documents the escaped Unicode sequence warning
- teach the shared query string linter to flag `\uXXXX` sequences in term tokens and surface the warning across platform linters
- cover the new check with a focused unit test

## Testing
- python -m pytest test/test_linter.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f65fc9bc832aab1027eb2be137c6)